### PR TITLE
Fix: Resolve multiple test suite errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 description = "Model Context Protocol (MCP) server and client for Tensorus tensor database"
 readme = "README.md"
 requires-python = ">=3.10"
-license = "MIT"
+license = {text = "MIT License"}
 keywords = [
     "mcp", "model-context-protocol", "tensor", "database", "ai", "pytorch", "fastapi"
 ]
@@ -15,7 +15,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/tensorus_mcp/__init__.py
+++ b/tensorus_mcp/__init__.py
@@ -8,7 +8,7 @@ __version__ = "1.0.0"
 __author__ = "Tensorus Team"
 __email__ = "ai@tensorus.com"
 
-from .client import TensorusMCPClient
+from .client import TensorusMCPClient, DEFAULT_MCP_URL
 from .server import create_mcp_app
 
-__all__ = ["TensorusMCPClient", "create_mcp_app"]
+__all__ = ["TensorusMCPClient", "create_mcp_app", "DEFAULT_MCP_URL"]

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -1,8 +1,8 @@
 import json
 import pytest
 
-from tensorus_mcp import mcp_client
-from tensorus_mcp.mcp_client import (
+from tensorus_mcp import client as mcp_client
+from tensorus_mcp.client import (
     TensorusMCPClient, TextContent, MCPResponseError, FastMCPError,
     DatasetListResponse, IngestTensorResponse, TensorDetailsResponse, SemanticMetadataResponse,
     MCP_AVAILABLE
@@ -385,4 +385,3 @@ async def test_call_json_validation_error_after_fallbacks(dummy_fast_client):
 # test_ingest_tensor, for example, relied on a simple hardcoded response.
 # The new DummyFastClient's default behavior for "tensorus_ingest_tensor" still provides
 # {"id": "tensor_id_123", "status": "ingested"}, so test_ingest_tensor should still pass.
-EOF < /dev/null

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4,8 +4,8 @@ import pytest
 import httpx
 from typing import Optional
 
-from tensorus_mcp import mcp_server
-from tensorus_mcp.mcp_server import MCP_AVAILABLE
+from tensorus_mcp import server as mcp_server
+from tensorus_mcp.server import MCP_AVAILABLE
 from tensorus_mcp.config import settings
 
 pytestmark = pytest.mark.skipif(
@@ -61,12 +61,11 @@ def make_mock_client(
 
 def test_create_empty_mcp_server():
     """Test that we can create an empty MCP server."""
-    server = mcp_server.create_server()
+    server = mcp_server.create_mcp_app()
     assert server is not None
 
 
 def test_settings_import():
     """Test that we can import and use settings."""
     assert settings is not None
-    assert hasattr(settings, 'tensorus_api_base_url')
-EOF < /dev/null
+    assert hasattr(settings, 'API_BASE_URL')


### PR DESCRIPTION
This commit addresses several issues that were causing the test suite to fail:

1.  **Dependency Installation:** Ensured `pytest` and `pytest-asyncio` are installed.
2.  **Syntax Errors:**
    *   Removed `EOF < /dev/null` artifacts from `tests/test_mcp_client.py` and `tests/test_mcp_server.py`.
    *   Corrected an `IndentationError` in `tests/test_mcp_integration.py` that arose during refactoring.
3.  **Configuration Errors:**
    *   Updated `pyproject.toml` to use the modern `license = {text = "..."}` format and removed the legacy license classifier, resolving a `pip install -e .` failure.
4.  **Import Errors:**
    *   Corrected import statements in `tests/test_mcp_client.py` and `tests/test_mcp_server.py` to use `from tensorus_mcp import client as mcp_client` and `from tensorus_mcp import server as mcp_server` respectively.
    *   Corrected import statements in `tests/test_mcp_integration.py` from `tensorus.*` to `tensorus_mcp.*`.
    *   Exposed `DEFAULT_MCP_URL` in `tensorus_mcp/__init__.py` to fix an `ImportError` in `examples/demo_app.py` when it was being (incorrectly) used as a mock API for integration tests.
5.  **Test Logic Errors:**
    *   In `tests/test_mcp_server.py`:
        *   Changed `mcp_server.create_server()` to `mcp_server.create_mcp_app()` to match the actual function name.
        *   Updated assertion from `settings.tensorus_api_base_url` to `settings.API_BASE_URL`.
    *   In `tests/test_mcp_integration.py`:
        *   The tests were attempting to run `examples/demo_app.py` (a Streamlit app) as a FastAPI backend for the `tensorus_mcp.server`. This was incorrect.
        *   The setup was modified to run `tensorus_mcp.server` directly in `--demo-mode`, so it uses internal mock responses and doesn't require an external FastAPI backend. This resolved the `RuntimeError: MCP server did not start or become ready in time` caused by the demo app failing to start as a uvicorn ASGI app.

The tests should now pass with these changes. The primary remaining issue before this fix was the `IndentationError` in `tests/test_mcp_integration.py`.